### PR TITLE
correct license MIT to GPLv3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,6 +60,6 @@
     "email": "ultimate.emoji.gen@gmail.com",
     "url": "https://github.com/emoji-gen"
   },
-  "license": "MIT",
+  "license": "GPLv3",
   "private": true
 }


### PR DESCRIPTION
Thank you as always for the great products!
I changed the MIT license to GPLv3 license according to the license in readme.md.