### PR TITLE
feat: open "Recently Log" image in a new tab when clicked

### DIFF
--- a/frontend/src/components/organisms/RecentlyLog.vue
+++ b/frontend/src/components/organisms/RecentlyLog.vue
@@ -87,6 +87,7 @@
           const node = baseNode.cloneNode(true)
           const imageUrl = '/img?code=' + recentlyLog.code
           node.style.backgroundImage = `url('${imageUrl}')`
+          node.addEventListener('click', () => window.open(imageUrl))
           // TODO
           // node.title = recentlyLog.text.replace(/\n/g, '')
           this.flkty.append(node)


### PR DESCRIPTION
This allows users to access raw images of "recently-log" so that users can download and modify them as they want. This feature encourages users to get inspired by others and actively interact on this web site.